### PR TITLE
improve simplified-mode platform checks and standardize image build D…

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -91,15 +91,25 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM xfan1024/openeuler:23.03-light
-RUN yum -y install java-17-openjdk --disableplugin=seccomp
+FROM maven:3.9.3-eclipse-temurin-17 as builder
+
+WORKDIR /work
+COPY . .
+
+RUN mvn -Dhttps.protocols=TLSv1.2 \
+    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN \
+    -Dorg.slf4j.simpleLogger.showDateTime=true \
+    -Djava.awt.headless=true \
+    -Dmaven.test.skip=true \
+    package
+
+FROM eclipse-temurin:17-jre
 ENV LANGUAGE='en_US:en'
 
-# We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
-COPY --chown=1001 target/quarkus-app/*.jar /deployments/
-COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
-COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=builder --chown=1001 /work/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=builder --chown=1001 /work/target/quarkus-app/*.jar /deployments/
+COPY --from=builder --chown=1001 /work/target/quarkus-app/app/ /deployments/app/
+COPY --from=builder --chown=1001 /work/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER root

--- a/Dockerfile.jvm.build
+++ b/Dockerfile.jvm.build
@@ -1,0 +1,28 @@
+# Build JVM artifacts then package runtime image.
+
+FROM maven:3.9.3-eclipse-temurin-17 as builder
+
+WORKDIR /work
+COPY . .
+
+RUN mvn -Dhttps.protocols=TLSv1.2 \
+    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN \
+    -Dorg.slf4j.simpleLogger.showDateTime=true \
+    -Djava.awt.headless=true \
+    -Dmaven.test.skip=true \
+    package
+
+FROM eclipse-temurin:17-jre
+ENV LANGUAGE='en_US:en'
+
+COPY --from=builder --chown=1001 /work/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=builder --chown=1001 /work/target/quarkus-app/*.jar /deployments/
+COPY --from=builder --chown=1001 /work/target/quarkus-app/app/ /deployments/app/
+COPY --from=builder --chown=1001 /work/target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER root
+ENV JAVA_OPTS="-Duser.timezone=GMT+8 -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+CMD ["java", "-jar", "-Dquarkus.http.host=0.0.0.0","/deployments/quarkus-run.jar"]

--- a/Dockerfile.jvm.prebuilt
+++ b/Dockerfile.jvm.prebuilt
@@ -1,0 +1,16 @@
+# Runtime-only image. Requires prebuilt target/quarkus-app.
+
+FROM eclipse-temurin:17-jre
+ENV LANGUAGE='en_US:en'
+
+COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001 target/quarkus-app/*.jar /deployments/
+COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
+COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER root
+ENV JAVA_OPTS="-Duser.timezone=GMT+8 -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+CMD ["java", "-jar", "-Dquarkus.http.host=0.0.0.0","/deployments/quarkus-run.jar"]

--- a/src/main/java/space/ao/services/account/member/service/MemberManageService.java
+++ b/src/main/java/space/ao/services/account/member/service/MemberManageService.java
@@ -347,7 +347,7 @@ public class MemberManageService {
   @SuppressWarnings("unused") // 开机自启动，写管理员信息
   public void createAdminFile() throws IOException {
     var file = new File(properties.accountDataLocation());
-    if(file.exists() || file.mkdirs()) {
+    if(!file.exists() && !file.mkdirs()) {
       LOG.error(ServiceError.CREATE_ADMIN_INIT_FAILED);
     }
     var data = new File(properties.accountDataLocation() + ServiceDefaultVar.DEFAULT_DATA_FILE);

--- a/src/main/java/space/ao/services/support/platform/check/CheckPlatformStatusInterceptor.java
+++ b/src/main/java/space/ao/services/support/platform/check/CheckPlatformStatusInterceptor.java
@@ -89,6 +89,12 @@ public class CheckPlatformStatusInterceptor {
         }
       }
       case PRODUCT -> {
+        // Simplified AOFS mode: internet access is disabled by design.
+        // Skip external product-platform probing to avoid repeated noisy warnings.
+        if (Boolean.FALSE.equals(operationUtils.getEnableInternetAccess())) {
+          LOG.debugv("Skip product platform check in simplified mode - request-id: {0}", requestId);
+          return ResponseBase.fromResponseBaseEnum(requestId, ResponseBaseEnum.PRODUCT_SERVICE_PLATFORM_ERROR).build();
+        }
         var productStatus = platformUtils.isOpstagePlatformAvailable(requestId);
         if (!productStatus) {
           return ResponseBase.fromResponseBaseEnum(requestId, ResponseBaseEnum.PRODUCT_SERVICE_PLATFORM_ERROR).build();


### PR DESCRIPTION
 Fixed admin init directory creation check in:
    - `MemberManageService`
  - Updated platform status interceptor:
    - In simplified mode (`enableInternetAccess = false`), skip external product
  platform probing.
    - Return existing product-platform error contract without repeated noisy
  connectivity checks.
  - Docker build updates:
    - Added `Dockerfile.jvm.build` for build-and-package flow (compile during
  image build).
    - Added `Dockerfile.jvm.prebuilt` for packaging prebuilt `target/quarkus-
  app`.
    - Updated `Dockerfile.jvm` to use a modern multi-stage JDK 17 build path.

  ## Why
  - Simplified deployments intentionally disable internet/platform access, so
  product platform probing creates avoidable error noise.
  - We need reproducible and explicit Docker build paths for both CI-style builds
  and prebuilt artifact workflows.

  ## Validation
  - Gateway image builds successfully with `Dockerfile.jvm.build`.
  - Existing API behavior remains compatible; only simplified-mode probing
  behavior is tightened.
  - Compose references are consistent with the new Dockerfile structure.

  ## Impact
  - Scope is `space-gateway` only.
  - No breaking API contract changes.
  - Improves operational clarity and deployment consistency.

Generated-by: Codex